### PR TITLE
Changed upper bound on `pipes` to `< 4.2`

### DIFF
--- a/pipes-rt.cabal
+++ b/pipes-rt.cabal
@@ -24,7 +24,7 @@ Library
   Hs-Source-Dirs: lib
   Build-Depends:
     base        (>= 4.2 && < 4.8)
-   ,pipes       (>= 4   && < 4.1)
+   ,pipes       (>= 4   && < 4.2)
    ,time        (>= 1.4 && < 1.5)
    ,mwc-random  (>= 0.13 && < 0.14)
   Exposed-Modules:


### PR DESCRIPTION
`pipes-4.1.0` got a version bump because it removes the dependency on the `void` package, which is only a breaking change if you used the `Void` type explicitly instead of the type synonyms.  For `pipes-rt` this is a backwards compatible change so this pull request just updates the upper bound.
